### PR TITLE
Add support for native swap partitions and zram device-backed writeback

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+rpi-swap (1.3.0) trixie; urgency=medium
+
+  * Add support for native swap partitions (swapdev mechanism)
+  * Add zram+device mechanism for direct device-backed writeback
+  * Auto mode now detects and prefers swap partitions
+  * Update documentation for device-backed swap workflows
+  * Clarify zram writeback behavior in man pages
+
+ -- Karl Tremain <karl@github.tremain.co.uk>  Thu, 26 Dec 2025 18:00:00 +0000
+
 rpi-swap (1.2.1) trixie; urgency=medium
 
   * man: Make swapfile example fixed size

--- a/etc/rpi/swap.conf
+++ b/etc/rpi/swap.conf
@@ -8,9 +8,11 @@
 
 [Main]
 #Mechanism=auto
+# Supported: auto, swapfile, swapdev, zram, zram+file, zram+device, none
 
 [File]
 #Path=/var/swap
+# For swapdev or zram+device, set Path to the block device (e.g. /dev/mmcblk0p3)
 #RamMultiplier=1
 #MaxSizeMiB=2048
 #MaxDiskPercent=50

--- a/lib/systemd/system-generators/rpi-swap-generator
+++ b/lib/systemd/system-generators/rpi-swap-generator
@@ -193,9 +193,9 @@ vm.page-cluster=0
 EOF
 }
 
-# Function to set up zram mechanisms (both zram and zram+file)
+# Function to set up zram mechanisms (zram, zram+file, zram+device)
 setup_zram_mechanism() {
-  local mechanism="$1"  # Either "zram" or "zram+file"
+  local mechanism="$1"  # "zram", "zram+file", or "zram+device"
 
   # Create sysctl optimizations for zram
   create_zram_sysctl_config
@@ -213,49 +213,61 @@ zram-size=${CONF_ZRAM_SIZE}"
   local bindings="[Unit]
 BindsTo=dev-%i.swap"
 
-  # For zram+file, set up backing file and add to config
-  if [ "${mechanism}" = "zram+file" ]; then
-    BACKING_FILE="$( \
-      systemd-escape \
-        --path \
-        "${CONF_SWAPFILE}" \
-    )"
-    local LOOP_DEVICE="/dev/disk/by-backingfile/${BACKING_FILE}"
+  case "${mechanism}" in
+    "zram+file")
+      BACKING_FILE="$( \
+        systemd-escape \
+          --path \
+          "${CONF_SWAPFILE}" \
+      )"
+      local LOOP_DEVICE="/dev/disk/by-backingfile/${BACKING_FILE}"
 
-    # Add writeback device to zram config
-    zram_config="${zram_config}
+      # Add writeback device to zram config
+      zram_config="${zram_config}
 writeback-device=${LOOP_DEVICE}"
 
-    # Add loop device to bindings
-    bindings="${bindings} rpi-setup-loop@${BACKING_FILE}.service"
+      # Add loop device to bindings
+      bindings="${bindings} rpi-setup-loop@${BACKING_FILE}.service"
 
-    # Create a drop-in for the loop service to ensure the swap file is resized
-    create_systemd_drop_in \
-      "generator" \
-      "rpi-setup-loop@${BACKING_FILE}.service" \
-      "resize-swap.conf" \
-      "[Unit]
+      # Create a drop-in for the loop service to ensure the swap file is resized
+      create_systemd_drop_in \
+        "generator" \
+        "rpi-setup-loop@${BACKING_FILE}.service" \
+        "resize-swap.conf" \
+        "[Unit]
 Requires=rpi-resize-swap-file.service
 After=rpi-resize-swap-file.service"
 
-    # Create a drop-in to avoid dependency cycles with swap.target
-    create_systemd_drop_in \
-      "generator" \
-      "rpi-setup-loop@${BACKING_FILE}.service" \
-      "no-dependency-cycle.conf" \
-      "[Unit]
+      # Create a drop-in to avoid dependency cycles with swap.target
+      create_systemd_drop_in \
+        "generator" \
+        "rpi-setup-loop@${BACKING_FILE}.service" \
+        "no-dependency-cycle.conf" \
+        "[Unit]
 DefaultDependencies=no
 Requires=systemd-remount-fs.service
 After=systemd-remount-fs.service"
 
-    # Create a drop-in to speed up symlink creation for swap use case
-    create_systemd_drop_in \
-      "generator" \
-      "rpi-setup-loop@${BACKING_FILE}.service" \
-      "fast-symlink.conf" \
-      "[Service]
-ExecStart=/bin/sh -c 'mkdir -p /dev/disk/by-backingfile && LOOP_DEV=\$(losetup --associated \"/%I\" | cut -d: -f1) && ln -s \"\$LOOP_DEV\" /dev/disk/by-backingfile/%i || true'"
-  fi
+      # Create a drop-in to speed up symlink creation for swap use case
+      create_systemd_drop_in \
+        "generator" \
+        "rpi-setup-loop@${BACKING_FILE}.service" \
+        "fast-symlink.conf" \
+        "[Service]
+ExecStart=/bin/sh -c 'mkdir -p /dev/disk/by-backingfile && LOOP_DEV=\$(losetup --associated \"/%I\" | cut -d: -f1) && ln -s \"$LOOP_DEV\" /dev/disk/by-backingfile/%i || true'"
+      ;;
+    "zram+device")
+      local DEVICE_UNIT
+      DEVICE_UNIT="$(systemd-escape --path --suffix=device "${CONF_SWAPFILE}")"
+
+      # Use the device directly for writeback
+      zram_config="${zram_config}
+writeback-device=${CONF_SWAPFILE}"
+
+      # Bind to the underlying block device to ensure ordering
+      bindings="${bindings} ${DEVICE_UNIT}"
+      ;;
+  esac
 
   # Create zram configuration
   create_systemd_drop_in \
@@ -264,7 +276,7 @@ ExecStart=/bin/sh -c 'mkdir -p /dev/disk/by-backingfile && LOOP_DEV=\$(losetup -
     "20-rpi-swap-zram0-ctrl.conf" \
     "${zram_config}"
 
-  # Create a swap unit with backing file conflict for zram+file
+  # Create a swap unit with backing file conflict for zram+file only
   local backing_file=""
   if [ "${mechanism}" = "zram+file" ]; then
     backing_file="${CONF_SWAPFILE}"
@@ -278,7 +290,7 @@ ExecStart=/bin/sh -c 'mkdir -p /dev/disk/by-backingfile && LOOP_DEV=\$(losetup -
     "bindings.conf" \
     "${bindings}"
 
-  # Create the ordering for zram+file mechanism
+  # Create ordering for backing resource setup
   if [ "${mechanism}" = "zram+file" ]; then
     create_systemd_drop_in \
       "generator" \
@@ -286,10 +298,18 @@ ExecStart=/bin/sh -c 'mkdir -p /dev/disk/by-backingfile && LOOP_DEV=\$(losetup -
       "ordering.conf" \
       "[Unit]
 After=rpi-setup-loop@${BACKING_FILE}.service"
+  elif [ "${mechanism}" = "zram+device" ]; then
+    create_systemd_drop_in \
+      "generator" \
+      "systemd-zram-setup@zram0.service" \
+      "ordering-device.conf" \
+      "[Unit]
+After=${DEVICE_UNIT}
+Requires=${DEVICE_UNIT}"
   fi
 
-  # For zram+file, we must mark the pages as idle before they're first used
-  if [ "${mechanism}" = "zram+file" ]; then
+  # Mark initial pages idle for writeback-backed zram
+  if [ "${mechanism}" = "zram+file" ] || [ "${mechanism}" = "zram+device" ]; then
     create_systemd_drop_in \
       "generator" \
       "systemd-zram-setup@zram0.service" \
@@ -326,7 +346,7 @@ eval "$( \
 
 # Sanitize mechanism - ensure it's one of the allowed values
 case "${CONF_MECHANISM}" in
-  swapfile|zram|zram+file|auto|none)
+  swapfile|swapdev|zram|zram+file|zram+device|auto|none)
     # Valid mechanism, do nothing
     ;;
   *)
@@ -348,7 +368,23 @@ esac
 
 # Handle auto mechanism
 if [ "${CONF_MECHANISM}" = "auto" ]; then
-  CONF_MECHANISM="zram+file"
+  # If the configured path is already a block device, prefer device-backed zram
+  if [ -b "${CONF_SWAPFILE}" ]; then
+    CONF_MECHANISM="zram+device"
+  else
+    # Otherwise, see if a swap partition exists and prefer it for writeback
+    AUTODETECT_SWAPDEV="$( \
+      blkid -t TYPE=swap -o device 2>/dev/null | \
+        grep -v '^/dev/zram' | \
+        head -n1 \
+    )"
+    if [ -n "${AUTODETECT_SWAPDEV}" ] && [ -b "${AUTODETECT_SWAPDEV}" ]; then
+      CONF_SWAPFILE="${AUTODETECT_SWAPDEV}"
+      CONF_MECHANISM="zram+device"
+    else
+      CONF_MECHANISM="zram+file"
+    fi
+  fi
 fi
 
 # Handle auto writeback initiator
@@ -357,11 +393,11 @@ if [ "${CONF_WRITEBACK_INITIATOR}" = "auto" ]; then
 fi
 
 # For 'zram' and 'none' mechanisms, we don't need a swap file at all
-if [ "${CONF_MECHANISM}" = "zram" ] || [ "${CONF_MECHANISM}" = "none" ]; then
-  # Skip calculation and set swap size to 0
+if [ "${CONF_MECHANISM}" = "zram" ] || [ "${CONF_MECHANISM}" = "zram+device" ] || [ "${CONF_MECHANISM}" = "none" ] || [ "${CONF_MECHANISM}" = "swapdev" ]; then
+  # Skip file sizing for pure zram / device-backed paths
   CONF_SWAPSIZE="0"
 else
-  # Calculate swap size for other mechanisms
+  # Calculate swap size for other mechanisms (file-backed)
   export \
     CONF_SWAPFILE \
     CONF_SWAPFACTOR \
@@ -371,8 +407,8 @@ else
   CONF_SWAPSIZE="$(${SWAP_FILE_SIZE_CALC_BIN})"
 fi
 
-# Calculate zram size for 'zram' and 'zram+file' mechanisms
-if [ "${CONF_MECHANISM}" = "zram" ] || [ "${CONF_MECHANISM}" = "zram+file" ]; then
+# Calculate zram size for zram-based mechanisms
+if [ "${CONF_MECHANISM}" = "zram" ] || [ "${CONF_MECHANISM}" = "zram+file" ] || [ "${CONF_MECHANISM}" = "zram+device" ]; then
   export \
     CONF_ZRAM_FACTOR \
     CONF_ZRAM_MAXSIZE \
@@ -384,6 +420,14 @@ fi
 
 CONF_SWAPFILE="$(realpath "${CONF_SWAPFILE}")"
 
+# Validate device-backed mechanisms early to avoid running file logic on them
+if [ "${CONF_MECHANISM}" = "swapdev" ] || [ "${CONF_MECHANISM}" = "zram+device" ]; then
+  if [ ! -b "${CONF_SWAPFILE}" ]; then
+    echo "Error: ${CONF_MECHANISM} requires a block device at ${CONF_SWAPFILE}" >&2
+    exit 1
+  fi
+fi
+
 if [ "${CONF_MECHANISM}" = "zram" ]; then
   setup_zram_mechanism "zram"
   if [ -f "${CONF_SWAPFILE}" ]; then
@@ -394,6 +438,14 @@ elif [ "${CONF_MECHANISM}" = "zram+file" ]; then
   if [ "${CONF_WRITEBACK_INITIATOR}" = "timer" ]; then
     create_writeback_units "${CONF_INITIAL_WRITEBACK_DELAY}" "${CONF_PERIODIC_WRITEBACK_INTERVAL}"
   fi
+elif [ "${CONF_MECHANISM}" = "zram+device" ]; then
+  setup_zram_mechanism "zram+device"
+  if [ "${CONF_WRITEBACK_INITIATOR}" = "timer" ]; then
+    create_writeback_units "${CONF_INITIAL_WRITEBACK_DELAY}" "${CONF_PERIODIC_WRITEBACK_INTERVAL}"
+  fi
+elif [ "${CONF_MECHANISM}" = "swapdev" ]; then
+  # Use a native block device for swap, rely on implicit device unit ordering
+  create_swap_unit "${CONF_SWAPFILE}" "$(systemd-escape --path --suffix=device "${CONF_SWAPFILE}")" ""
 elif [ "${CONF_MECHANISM}" = "none" ]; then
   # No swap setup at all, but clean up existing swap file if present
   if [ -f "${CONF_SWAPFILE}" ]; then

--- a/man/man5/swap.conf.5
+++ b/man/man5/swap.conf.5
@@ -29,16 +29,20 @@ All options are configured in the [Main], [File], or [Zram] sections.
 
 .TP
 \fBMechanism=\fR
-Controls which swap mechanism to use. One of "auto", "swapfile", "zram", "zram+file", and "none".
+Controls which swap mechanism to use. One of "auto", "swapfile", "swapdev", "zram", "zram+file", "zram+device", and "none".
 .RS
 .IP \(bu 2
-\fBauto\fR: Automatically selects the most appropriate mechanism. At present, this defaults to "zram+file", but the default may change in future releases. If you require a specific mechanism to always be used, set it explicitly.
+\fBauto\fR: Automatically selects the most appropriate mechanism. If a swap partition is detected (or \fBFile::Path\fR already points to a block device), auto prefers "zram+device" and uses that device for writeback. Otherwise it falls back to "zram+file". The creation of a swap partition is not automated; users must provision it themselves if they want auto to choose the device-backed path.
 .IP \(bu 2
 \fBswapfile\fR: A traditional swap file is created on the root filesystem.
 .IP \(bu 2
+\fBswapdev\fR: An existing block device (partition or disk) specified by \fBFile::Path\fR is activated directly as swap. No file resizing or creation occurs. Provisioning the swap partition is a manual step and is not performed by rpi-swap.
+.IP \(bu 2
 \fBzram\fR: A compressed RAM-based swap device is created. No swap file is used.
 .IP \(bu 2
-\fBzram+file\fR: A compressed RAM-based swap device is created, with the file specified in \fBFile::Path\fR used for writeback storage. The file is not used as a traditional swap device; instead, zram occasionally writes idle pages to it to free up RAM, reducing SD card wear through infrequent writes.
+\fBzram+file\fR: A compressed RAM-based swap device is created, with the file specified in \fBFile::Path\fR used for writeback storage. The file is not used as a traditional swap device; instead, zram occasionally writes idle pages to it to free up RAM, reducing SD card wear through infrequent writes. Only the zram device will appear in \fBswapon -s\fR output; the backing file is not activated as swap.
+.IP \(bu 2
+\fBzram+device\fR: A compressed RAM-based swap device is created, with the block device specified in \fBFile::Path\fR used directly for writeback storage. No loop device or file is created; the device must already exist. Provisioning the swap partition is a manual step and is not performed by rpi-swap. Only the zram device will appear in \fBswapon -s\fR output; the backing device serves as writeback storage, not active swap.
 .IP \(bu 2
 \fBnone\fR: No swap is configured. Any existing swap file will be removed to free up disk space.
 .RE
@@ -46,11 +50,11 @@ Controls which swap mechanism to use. One of "auto", "swapfile", "zram", "zram+f
 Defaults to "\fBauto\fR".
 
 .SS "[File] Section Options"
-These options configure the file used by both the "swapfile" and "zram+file" mechanisms. For "swapfile", the file serves as the primary swap device. For "zram+file", it serves as writeback storage where zram occasionally writes idle pages to free up RAM, accessed via a loop device. These options are disregarded for mechanisms that don't involve a file (e.g. "zram"), and any existing file will be removed to free up disk space.
+These options configure the file or device used by swap-capable mechanisms. For "swapfile", the path serves as the primary swap file. For "swapdev", the path must be an existing block device that is activated directly as swap. For "zram+file", the path serves as writeback storage via a loop device. For "zram+device", the path must be an existing block device used directly for writeback. These options are disregarded for mechanisms that don't involve an external backing store (e.g. "zram"), and any existing file will be removed to free up disk space.
 
 .TP
 \fBPath=\fR
-The path to the swap file. This is used directly by the "swapfile" mechanism, and as writeback storage via a loop device for the "zram+file" mechanism. Defaults to "\fB/var/swap\fR".
+The path to the swap backing resource. For "swapfile", this is the swap file. For "swapdev", this must be the block device to activate as swap. For "zram+file", this is the writeback file (loop-mounted). For "zram+device", this must be the block device used for writeback. Defaults to "\fB/var/swap\fR".
 
 .TP
 \fBRamMultiplier=\fR
@@ -69,9 +73,11 @@ The maximum percentage of available disk space to use for the file, to prevent i
 A fixed file size in MiB (mebibytes). If set, this value overrides the \fBRamMultiplier\fR calculation and is used directly to set the exact file size.
 
 .SS "[Zram] Section Options"
-These options configure the zram (compressed RAM) swap device used by both the "zram" and "zram+file" mechanisms.
+These options configure the zram (compressed RAM) swap device used by the "zram", "zram+file", and "zram+device" mechanisms.
 
 When zram mechanisms are enabled, the system automatically optimises kernel parameters for compressed swap performance. This includes setting vm.page-cluster=0 to disable readahead, which reduces latency with minimal throughput impact on compressed RAM swap devices.
+
+\fBNote:\fR With zram-based mechanisms, only the zram device (e.g., /dev/zram0) appears as active swap in \fBswapon -s\fR output. For "zram+file" and "zram+device" mechanisms, the backing file or device is used exclusively for writeback and will not appear as a separate swap device.
 
 .TP
 \fBRamMultiplier=\fR
@@ -85,7 +91,9 @@ The maximum zram decompressed capacity in MiB (mebibytes). This limits the zram 
 \fBFixedSizeMiB=\fR
 A fixed zram decompressed capacity in MiB (mebibytes). If set, this value overrides the \fBRamMultiplier\fR calculation and is used directly to set the exact zram virtual capacity.
 
-The following options control writeback behaviour for the "zram+file" mechanism. Writeback allows zram to move idle pages to the writeback file, freeing up RAM while reducing SD card wear through infrequent writes. These writeback options are ignored for other mechanisms.
+The following options control writeback behaviour for the "zram+file" and "zram+device" mechanisms. Writeback allows zram to move idle pages to the writeback file or device, freeing up RAM while reducing flash wear through infrequent writes. These writeback options are ignored for other mechanisms.
+
+\fBImportant:\fR The backing file or device is not activated as traditional swap and will not appear in \fBswapon -s\fR. To verify writeback is configured, check \fB/sys/block/zram0/backing_dev\fR, which should display the path to your writeback file or device.
 
 .TP
 \fBWritebackTrigger=\fR
@@ -165,6 +173,46 @@ EOF
 .fi
 
 This will disable all swap mechanisms and remove any existing swap file to free up disk space. This is useful for systems with abundant RAM where swap is not required.
+
+.B After creating this configuration file, reboot the system for the changes to take effect.
+
+.SS "Example 3. Using a swap partition"
+
+To use an existing swap partition (for example, /dev/mmcblk0p3) instead of a file, create a drop-in configuration file:
+
+.nf
+sudo mkdir -p /etc/rpi/swap.conf.d/
+sudo tee /etc/rpi/swap.conf.d/70-use-swapdev.conf > /dev/null <<EOF
+[Main]
+Mechanism=swapdev
+
+[File]
+Path=/dev/mmcblk0p3
+EOF
+.fi
+
+This will activate the specified block device directly as swap. No file will be created or resized. Ensure the device exists at boot and contains no filesystem data you wish to keep.
+
+.B After creating this configuration file, reboot the system for the changes to take effect.
+
+.SS "Example 4. Using zram with a backing device"
+
+To use zram with direct writeback to an existing block device (for example, /dev/mmcblk0p3) instead of a file-backed loop device, create a drop-in configuration file:
+
+.nf
+sudo mkdir -p /etc/rpi/swap.conf.d/
+sudo tee /etc/rpi/swap.conf.d/75-use-zram-device.conf > /dev/null <<EOF
+[Main]
+Mechanism=zram+device
+
+[File]
+Path=/dev/mmcblk0p3
+EOF
+.fi
+
+This configures a compressed zram swap device with writeback going directly to the specified block device. No file is created or resized. Ensure the device exists at boot and is safe to overwrite with swap data.
+
+\fBNote:\fR Only /dev/zram0 will appear in \fBswapon -s\fR output. The backing device serves as writeback storage for idle pages and is not activated as traditional swap. To verify the configuration, run: \fBcat /sys/block/zram0/backing_dev\fR
 
 .B After creating this configuration file, reboot the system for the changes to take effect.
 

--- a/man/man8/rpi-swap-generator.8
+++ b/man/man8/rpi-swap-generator.8
@@ -22,11 +22,11 @@ Resizes swap files during early boot before they are activated, avoiding memory 
 
 .TP
 \fBMultiple swap mechanisms\fR
-Supports traditional swap files, zram compression, and hybrid zram+file approaches.
+Supports traditional swap files, native swap partitions, zram compression, and hybrid zram+file or zram+device writeback approaches.
 
 .TP
 \fBAutomatic writeback\fR
-For hybrid configurations, implements intelligent writeback of less active pages from compressed memory to storage.
+For hybrid configurations, implements intelligent writeback of less active pages from compressed memory to storage (file-backed via loop or directly to a block device).
 
 .TP
 \fBPerformance optimisation\fR

--- a/usr/lib/rpi-swap/bin/rpi-desired-swap-size
+++ b/usr/lib/rpi-swap/bin/rpi-desired-swap-size
@@ -5,6 +5,16 @@ set -e
 : "${CONF_SWAPFILE:=/var/swap}"
 : "${CONF_SWAPFACTOR:=1}"
 
+# If a native block device is provided, skip file-based sizing logic.
+if [ -b "${CONF_SWAPFILE}" ]; then
+  if [ -n "${CONF_SWAPSIZE}" ] && [ "${CONF_SWAPSIZE}" -eq "${CONF_SWAPSIZE}" ] 2>/dev/null; then
+    echo "${CONF_SWAPSIZE}"
+  else
+    echo "0"
+  fi
+  exit 0
+fi
+
 # Function to validate floating-point input
 validate_float() {
   local value="$1"

--- a/usr/lib/rpi-swap/bin/rpi-resize-swap-file
+++ b/usr/lib/rpi-swap/bin/rpi-resize-swap-file
@@ -23,6 +23,11 @@ export \
 CONF_SWAPSIZE="$(${SWAP_FILE_SIZE_CALC_BIN})"
 CONF_SWAPFILE="$(realpath "${CONF_SWAPFILE}")"
 
+# Skip resize logic when a block device is provided; sizing a device is not supported here.
+if [ -b "${CONF_SWAPFILE}" ]; then
+  exit 0
+fi
+
 # Note, fallocate can be used to create / grow / but not shrink
 
 if [ "${CONF_SWAPSIZE}" -eq 0 ]; then


### PR DESCRIPTION
This PR provides the ability to use swap partitions in addition to files

This provides a benefit if attempting to work with ram-limited devices where writes to the primary mounted filesystem are to be avoided - e.g. when using overlayroot to make the filesystem read-only

- Implement swapdev mechanism to activate existing block devices as swap
- Add zram+device mechanism for zram writeback to block devices
- Auto mode now detects swap partitions and prefers device-backed writeback
- Update rpi-desired-swap-size to skip file logic for block devices
- Update rpi-resize-swap-file to no-op on block devices
- Add validation to ensure device-backed mechanisms point to block devices
- Document new mechanisms and Path semantics in swap.conf.5
- Update rpi-swap-generator.8 to mention partition and device support
- Add configuration examples for swapdev and zram+device usage

Note that swap partition creation is an optional manual user responsibility

I'm aware that the config section is still headed as [file] despite handling paths, and would appreciate any comments or feedback on naming.